### PR TITLE
Refactoring private methods to be protected

### DIFF
--- a/src/CsvHeaderParser.php
+++ b/src/CsvHeaderParser.php
@@ -61,7 +61,7 @@ class CsvHeaderParser
      *
      * @return void
      */
-    private function aliasColumns()
+    protected function aliasColumns()
     {
         if( empty($this->aliases) ) return;
 
@@ -77,7 +77,7 @@ class CsvHeaderParser
      *
      * @return void
      */
-    private function skipColumns()
+    protected function skipColumns()
     {
         if( ! isset($this->skipper) ) return;
 
@@ -89,7 +89,7 @@ class CsvHeaderParser
      *
      * @return void
      */
-    private function checkColumns()
+    protected function checkColumns()
     {
         if( ! in_array($this->name, $this->table) ) unset($this->parsedHeader[$this->key]);
     }

--- a/src/CsvHeaderParser.php
+++ b/src/CsvHeaderParser.php
@@ -11,14 +11,14 @@ use Illuminate\Support\Facades\DB;
  */
 class CsvHeaderParser
 {
-    private $aliases      = [];
-    private $skipper      = '%';
+    protected $aliases      = [];
+    protected $skipper      = '%';
 
-    private $table;
-    private $key;
-    private $name;
+    protected $table;
+    protected $key;
+    protected $name;
 
-    private $parsedHeader = [];
+    protected $parsedHeader = [];
 
     /**
      * Set the tablename

--- a/src/CsvRowParser.php
+++ b/src/CsvRowParser.php
@@ -12,19 +12,19 @@ use Illuminate\Support\Facades\Hash;
  */
 class CsvRowParser
 {
-    private $header;
-    private $empty        = FALSE;
-    private $defaults     = [];
-    private $timestamps   = TRUE;
-    private $parsers      = [];
-    private $hashable     = ['password'];
-    private $validate     = [];
-    private $encode       = TRUE;
+    protected $header;
+    protected $empty        = FALSE;
+    protected $defaults     = [];
+    protected $timestamps   = TRUE;
+    protected $parsers      = [];
+    protected $hashable     = ['password'];
+    protected $validate     = [];
+    protected $encode       = TRUE;
 
-    private $key;
-    private $value;
-    private $row;
-    private $parsedRow;
+    protected $key;
+    protected $value;
+    protected $row;
+    protected $parsedRow;
 
     /**
      * Set the header and possible options to add or parse a row

--- a/src/CsvRowParser.php
+++ b/src/CsvRowParser.php
@@ -100,7 +100,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function mergeRowAndHeader( )
+    protected function mergeRowAndHeader( )
     {
         foreach( $this->header as $key => $value )
         {
@@ -115,7 +115,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function init()
+    protected function init()
     {
         $this->parsedRow = [];
     }
@@ -125,7 +125,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function doValidate()
+    protected function doValidate()
     {
         if( empty($this->validate) ) return TRUE;
 
@@ -141,7 +141,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function isEmptyValue()
+    protected function isEmptyValue()
     {
         if( $this->empty === FALSE and $this->value === '' ) $this->value = NULL;
 
@@ -157,7 +157,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function doParse()
+    protected function doParse()
     {
 
         if( empty($this->parsers) ) return;
@@ -176,7 +176,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function doEncode()
+    protected function doEncode()
     {
         if( $this->encode === FALSE ) return;
 
@@ -188,7 +188,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function doHashable()
+    protected function doHashable()
     {
         if( empty($this->hashable) ) return;
 
@@ -202,7 +202,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function addDefaults()
+    protected function addDefaults()
     {
         if( empty($this->defaults) ) return;
 
@@ -219,7 +219,7 @@ class CsvRowParser
      *
      * @return void
      */
-    private function addTimestamps()
+    protected function addTimestamps()
     {
         if( empty($this->timestamps) ) return;
 

--- a/src/CsvSeeder.php
+++ b/src/CsvSeeder.php
@@ -200,7 +200,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function setConnection()
+    protected function setConnection()
     {
         if ($this->connection !== NULL) return;
 
@@ -213,7 +213,7 @@ class CsvSeeder extends Seeder
      *
      * @return boolean
      */
-    private function checkFile()
+    protected function checkFile()
     {
         if( $this->file ) return TRUE;
 
@@ -227,7 +227,7 @@ class CsvSeeder extends Seeder
      *
      * @return boolean
      */
-    private function checkFilepath()
+    protected function checkFilepath()
     {
         $this->filepath = $this->file;
 
@@ -247,7 +247,7 @@ class CsvSeeder extends Seeder
      *
      * @return boolean
      */
-    private function checkTablename()
+    protected function checkTablename()
     {
         if( ! isset($this->tablename) )
         {
@@ -268,7 +268,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function seeding()
+    protected function seeding()
     {
         $this->truncateTable();
 
@@ -294,7 +294,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function truncateTable()
+    protected function truncateTable()
     {
         if( $this->truncate === FALSE ) return;
 
@@ -310,7 +310,7 @@ class CsvSeeder extends Seeder
      *
      * @param boolean $mode
      */
-    private function toggleForeignKeyCheck( $mode )
+    protected function toggleForeignKeyCheck( $mode )
     {
         if( $this->foreignKeyCheck === FALSE ) return;
 
@@ -330,7 +330,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function setTotal()
+    protected function setTotal()
     {
         $file = file( $this->filepath, FILE_SKIP_EMPTY_LINES );
 
@@ -344,7 +344,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function openCSV()
+    protected function openCSV()
     {
         $this->csvData = fopen( $this->filepath, 'r' );;
     }
@@ -354,7 +354,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function setHeader()
+    protected function setHeader()
     {
         if( $this->header == FALSE ) return;
 
@@ -369,7 +369,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function setMapping()
+    protected function setMapping()
     {
         if( empty($this->mapping) ) return;
 
@@ -381,7 +381,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function parseHeader()
+    protected function parseHeader()
     {
         if( empty($this->header) ) return $this->console( 'No CSV headers were parsed' );
 
@@ -395,7 +395,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function parseCSV()
+    protected function parseCSV()
     {
         if( ! $this->csvData || empty($this->header) ) return;
 
@@ -428,7 +428,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function insertRows()
+    protected function insertRows()
     {
         if( empty($this->parsedData) ) return;
 
@@ -455,7 +455,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function closeCSV()
+    protected function closeCSV()
     {
         if( ! $this->csvData ) return;
 
@@ -467,7 +467,7 @@ class CsvSeeder extends Seeder
      *
      * @return void
      */
-    private function outputParsed()
+    protected function outputParsed()
     {
         $this->console( $this->count.' of '.$this->total.' rows has been seeded in table "'.$this->tablename.'"' );
     }
@@ -478,7 +478,7 @@ class CsvSeeder extends Seeder
      * @param [type] $string
      * @return string
      */
-    private function stripUtf8Bom( $string )
+    protected function stripUtf8Bom( $string )
     {
         $bom    = pack('H*', 'EFBBBF');
         $string = preg_replace("/^$bom/", '', $string);
@@ -493,7 +493,7 @@ class CsvSeeder extends Seeder
      * @param string $level
      * @return void
      */
-    private function console( $message, $level = FALSE )
+    protected function console( $message, $level = FALSE )
     {
         if (isset($this->command) === FALSE) return;
 

--- a/src/CsvSeeder.php
+++ b/src/CsvSeeder.php
@@ -171,11 +171,11 @@ class CsvSeeder extends Seeder
     public $encode = TRUE;
 
 
-    private $filepath;
-    private $csvData;
-    private $parsedData;
-    private $count = 0;
-    private $total = 0;
+    protected $filepath;
+    protected $csvData;
+    protected $parsedData;
+    protected $count = 0;
+    protected $total = 0;
 
     /**
      * Run the class


### PR DESCRIPTION
## Motivation
Not all imports are simple CSV column to table column mappings. When there are complex relationships as part of the import data the ability to alter the process is required to avoid errors or missing related content.

## Changes
Empower users to alter parts of the import process they deem fit by making `private` methods `protected`