### PR TITLE
Add support for csv URLs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-	"name": "jeroenzwart/laravel-csv-seeder",
+	"name": "denisd3d/laravel-csv-seeder",
 	"description": "Seed the database with Laravel using CSV files",
-	"homepage": "https://github.com/jeroenzwart/laravel-csv-seeder",
+	"homepage": "https://github.com/DenisD3D/laravel-csv-seeder",
 	"authors": [
 		{
 			"name": "Jeroen Zwart",

--- a/src/CsvSeeder.php
+++ b/src/CsvSeeder.php
@@ -231,6 +231,10 @@ class CsvSeeder extends Seeder
     {
         $this->filepath = $this->file;
 
+        if (filter_var($this->filepath, FILTER_VALIDATE_URL)) {
+            return TRUE;
+        }
+
         if( file_exists( $this->filepath ) || is_readable( $this->filepath ) ) return TRUE;
 
         $this->filepath = base_path() . $this->file;


### PR DESCRIPTION
Add a check fir an url in checkFilepath to allow using online csv. Everything else was already working properly. Tested with a google sheets:
```csv
$this->file = 'https://docs.google.com/spreadsheets/d/{DOCUMENT_ID_GOES_HERE}/gviz/tq?tqx=out:csv&sheet={SHEET_NAME_GOES_HERE}';
        $this->tablename = 'MY_TABLE_NAME';
        $this->delimiter = ',';
```